### PR TITLE
Confirm field sets are non-null before removing hidden fields

### DIFF
--- a/lib/object-definition.js
+++ b/lib/object-definition.js
@@ -60,13 +60,13 @@ ObjectDefinition.prototype.build = function(object) {
 
       for (var key in schema.properties) {
           if (schema.properties[key].noDisplay === true) {
-              if (self.allProps[key]) {
+              if (self.allProps && self.allProps[key]) {
                 delete self.allProps[key];
               }
-              if (self.optionalProps[key]) {
+              if (self.optionalProps && self.optionalProps[key]) {
                 delete self.optionalProps[key];
               }
-              if (self.requiredProps[key]) {
+              if (self.requiredProps && self.requiredProps[key]) {
                 delete self.requiredProps[key];
               }
           }


### PR DESCRIPTION
When empty, `{all,optional,required}Props` are set to `null` which we need to check for before attempting to delete from.