### PR TITLE
Add properties required by array items onto the parent

### DIFF
--- a/lib/object-definition.js
+++ b/lib/object-definition.js
@@ -115,6 +115,7 @@ ObjectDefinition.prototype.build = function(object) {
       self.allProps = {};
     }
     _.extend(self.allProps, this.defineProperties(object.items.properties));
+    required = required.concat(object.items.required || []);
 
     if (_.isPlainObject(object.items.additionalProperties)) {
       _.extend(self.allProps, this.defineProperties(object.items.additionalProperties));


### PR DESCRIPTION
Without this, it looks like arrays of objects have zero required attributes.