### PR TITLE
When resolving $refs, retain existing properties, such as description.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -76,7 +76,7 @@ Resolver.prototype.dereferenceSchema = function (schema, context, prop, stack) {
       // Assign the resolved reference as the schema for this prop/stack loop.
       // Pass along the resolved ID if it's a valid schema, to
       // force a context change when recursing
-      schema = this.dereferenceSchema(resolved, this._normalizeReference(item, context), prop, stack);
+      schema = _.defaults(schema, this.dereferenceSchema(resolved, this._normalizeReference(item, context), prop, stack));
       // Quit this loop once we've found a `$ref`
       return false;
     }


### PR DESCRIPTION
It's quite common when using $ref to re-use a definition that you'll want to provide a description about the context in which a type is used. For example:

```json
{"definitions": {
    "timestamp": {
        "type": "integer",
        "description": "Some unix timestamp"},
    "account": {
        "registrationTime": {
            "$ref": "#/definitions/timestamp",
            "description": "When signup was completed."},
        "emailVerificationTime": {
            "$ref": "#/definitions/timestamp",
            "description": "When email was verified."}}}
```

Prior to this code change, the descriptions on registrationTime and emailVerificationTime would have been discarded. With this code change, we keep the more informative description! Huzzah.