### PR TITLE
Add definition for items.oneOf and items.anyOf

### DIFF
--- a/lib/object-definition.js
+++ b/lib/object-definition.js
@@ -187,10 +187,21 @@ ObjectDefinition.prototype.defineProperty = function(property) {
       if (defined) definition.example = defined.example
       return defined
     }));
-
-  // If the property value is an object and has its own properties,
-  // make them available to the definition
-  } else if (property.properties) {
+  } else if (property.items?.oneOf || property.items?.anyOf){
+    var key = property.items.oneOf ? 'oneOf' : 'anyOf';
+    definition[key] = _.filter(_.map(property.items.oneOf || property.items.anyOf, (object) => {
+      if (object.type == 'object' ||object.type == 'array') {
+        return this.build(object);
+      }
+      var defined = this.defineProperty(object);
+      if (defined) definition.example = defined.example
+      return defined
+    }));
+      
+    // If the property value is an object and has its own properties,
+    // make them available to the definition
+  } 
+  else if (property.properties) {
     definition.properties = this.defineProperties(property.properties);
   } else if (property.items && property.items.properties){
     definition.properties = this.defineProperties(property.items.properties);


### PR DESCRIPTION
Fixes property definition of oneOf and anyOf fields when they used inside of an array.

For example when we define an array of [paymentMethods](https://github.com/unravelin/core/blob/master/event-decoding-service/static/schemas/v2/yaml/endpoints/checkout.api.yaml#L51-L57) we are not able to display it's [oneOf](https://github.com/unravelin/core/blob/master/event-decoding-service/static/schemas/v2/yaml/paymentmethod.yaml#L19-L39) properties in [docs](https://developer.ravelin.com/api/endpoints/checkout/#checkout.paymentMethods).
